### PR TITLE
Scene Detection with gap to detect transitions + Alternate way to split video to chunks added

### DIFF
--- a/scenedetect/backends/opencv.py
+++ b/scenedetect/backends/opencv.py
@@ -26,7 +26,12 @@ from logging import getLogger
 import cv2
 import numpy as np
 
-from scenedetect.common import _USE_PTS_IN_DEVELOPMENT, MAX_FPS_DELTA, FrameTimecode, Timecode
+from scenedetect.common import (
+    _USE_PTS_IN_DEVELOPMENT,
+    MAX_FPS_DELTA,
+    FrameTimecode,
+    Timecode,
+)
 from scenedetect.platform import get_file_name
 from scenedetect.video_stream import (
     FrameRateUnavailable,
@@ -91,7 +96,9 @@ class VideoStreamCv2(VideoStream):
         super().__init__()
         # TODO(v0.7): Replace with DeprecationWarning that `path_or_device` will be removed in v0.8.
         if path_or_device is not None:
-            logger.error("path_or_device is deprecated, use path or VideoCaptureAdapter instead.")
+            logger.error(
+                "path_or_device is deprecated, use path or VideoCaptureAdapter instead."
+            )
             path = path_or_device
         if path is None:
             raise ValueError("Path must be specified!")
@@ -282,7 +289,9 @@ class VideoStreamCv2(VideoStream):
         self._cap.release()
         self._open_capture(self._frame_rate)
 
-    def read(self, decode: bool = True, advance: bool = True) -> ty.Union[np.ndarray, bool]:
+    def read(
+        self, decode: bool = True, advance: bool = True
+    ) -> ty.Union[np.ndarray, bool]:
         """Read and decode the next frame as a np.ndarray. Returns False when video ends,
         or the maximum number of decode attempts has passed.
 
@@ -311,7 +320,9 @@ class VideoStreamCv2(VideoStream):
                     self._decode_failures += 1
                     logger.debug("Frame failed to decode.")
                     if not self._warning_displayed and self._decode_failures > 1:
-                        logger.warning("Failed to decode some frames, results may be inaccurate.")
+                        logger.warning(
+                            "Failed to decode some frames, results may be inaccurate."
+                        )
             # We didn't manage to grab a frame even after retrying, so just return.
             if not has_grabbed:
                 return False
@@ -322,6 +333,42 @@ class VideoStreamCv2(VideoStream):
             return frame
         return self._has_grabbed
 
+    def read_fps(
+        self,
+        target_fps: float = 5.0,
+        decode: bool = True,
+    ) -> ty.Union[np.ndarray, bool]:
+        """Read and decode the next frame, skipping enough frames so that the
+        effective output rate is ~target_fps.
+
+        Arguments:
+            target_fps: Desired output frame rate (e.g. 5.0).
+            decode: If True, decode and return the frame; else only advance.
+
+        Returns:
+            Frame (np.ndarray) or False if end of video.
+        """
+        if not self._cap.isOpened():
+            return False
+
+        input_fps = self.frame_rate
+        if input_fps <= 0:
+            raise FrameRateUnavailable("Input FPS could not be determined.")
+
+        # how many frames to skip between reads
+        skip = max(1, int(round(input_fps / target_fps)))
+
+        # grab/skip frames
+        for _ in range(skip):
+            has_grabbed = self._cap.grab()
+            if not has_grabbed:
+                return False
+
+        if decode:
+            _, frame = self._cap.retrieve()
+            return frame
+        return True
+
     #
     # Private Methods
     #
@@ -331,7 +378,8 @@ class VideoStreamCv2(VideoStream):
         if self._is_device and self._path_or_device < 0:
             raise ValueError("Invalid/negative device ID specified.")
         input_is_video_file = not self._is_device and not any(
-            identifier in self._path_or_device for identifier in NON_VIDEO_FILE_INPUT_IDENTIFIERS
+            identifier in self._path_or_device
+            for identifier in NON_VIDEO_FILE_INPUT_IDENTIFIERS
         )
         # We don't have a way of querying why opening a video fails (errors are logged at least),
         # so provide a better error message if we try to open a file that doesn't exist.
@@ -359,7 +407,9 @@ class VideoStreamCv2(VideoStream):
 
         # Ensure the framerate is correct to avoid potential divide by zero errors. This can be
         # addressed in the PyAV backend if required since it supports integer timebases.
-        assert framerate is None or framerate > MAX_FPS_DELTA, "Framerate must be validated if set!"
+        assert (
+            framerate is None or framerate > MAX_FPS_DELTA
+        ), "Framerate must be validated if set!"
         if framerate is None:
             framerate = cap.get(cv2.CAP_PROP_FPS)
             if framerate < MAX_FPS_DELTA:
@@ -368,7 +418,9 @@ class VideoStreamCv2(VideoStream):
         self._cap = cap
         self._frame_rate = framerate
         self._has_grabbed = False
-        cap.set(cv2.CAP_PROP_ORIENTATION_AUTO, 1.0)  # https://github.com/opencv/opencv/issues/26795
+        cap.set(
+            cv2.CAP_PROP_ORIENTATION_AUTO, 1.0
+        )  # https://github.com/opencv/opencv/issues/26795
 
 
 # TODO(#168): Support non-monotonic timing for `position`. VFR timecode support is a
@@ -529,7 +581,9 @@ class VideoCaptureAdapter(VideoStream):
         """Not supported."""
         raise NotImplementedError("Reset is not supported.")
 
-    def read(self, decode: bool = True, advance: bool = True) -> ty.Union[np.ndarray, bool]:
+    def read(
+        self, decode: bool = True, advance: bool = True
+    ) -> ty.Union[np.ndarray, bool]:
         """Read and decode the next frame as a np.ndarray. Returns False when video ends,
         or the maximum number of decode attempts has passed.
 
@@ -557,7 +611,9 @@ class VideoCaptureAdapter(VideoStream):
                     self._decode_failures += 1
                     logger.debug("Frame failed to decode.")
                     if not self._warning_displayed and self._decode_failures > 1:
-                        logger.warning("Failed to decode some frames, results may be inaccurate.")
+                        logger.warning(
+                            "Failed to decode some frames, results may be inaccurate."
+                        )
             # We didn't manage to grab a frame even after retrying, so just return.
             if not has_grabbed:
                 return False
@@ -566,6 +622,35 @@ class VideoCaptureAdapter(VideoStream):
             self._num_frames += 1
         # Need to make sure we actually grabbed a frame before calling retrieve.
         if decode and self._num_frames > 0:
+            _, frame = self._cap.retrieve()
+            return frame
+        return True
+
+    def read_fps(
+        self, target_fps: float = 5.0, decode: bool = True
+    ) -> ty.Union[np.ndarray, bool]:
+        """Read next frame downsampled to target_fps by skipping intermediate frames."""
+        if not self._cap.isOpened():
+            return False
+
+        input_fps = self.frame_rate
+        if input_fps <= 0:
+            raise FrameRateUnavailable("Input FPS could not be determined.")
+
+        skip = max(1, int(round(input_fps / target_fps)))
+
+        has_grabbed = False
+        for _ in range(skip):
+            has_grabbed = self._cap.grab()
+            if not has_grabbed:
+                return False
+
+        if self._num_frames == 0:
+            # establish baseline timestamp
+            self._time_base = self._cap.get(cv2.CAP_PROP_POS_MSEC)
+        self._num_frames += 1
+
+        if decode and has_grabbed:
             _, frame = self._cap.retrieve()
             return frame
         return True

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -220,7 +220,18 @@ def invoke_command(args: ty.List[str]) -> int:
         CommandTooLong: `args` exceeds built in command line length limit on Windows.
     """
     try:
-        return subprocess.call(args)
+        try:
+            result = subprocess.run(args,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True  # decode bytes -> str
+            )
+            return result
+        except subprocess.CalledProcessError as e:
+            print("❌ FFmpeg failed!")
+            print("Return code:", e.returncode)
+            print("Error output:\n", e.stderr)   # full ffmpeg log
         # return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError as err:
         if os.name != "nt":

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -220,10 +220,15 @@ def invoke_command(args: ty.List[str]) -> int:
         CommandTooLong: `args` exceeds built in command line length limit on Windows.
     """
     try:
-        try:
-            return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        except subprocess.CalledProcessError as e:
-            print(f"FFmpeg failed - {e}")
+        # return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        print(result)
+        if result.returncode != 0:
+            print("ffmpeg failed!")
+            print("Error log:\n", result.stderr)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"FFmpeg failed - {e}")
     except OSError as err:
         if os.name != "nt":
             raise

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -220,7 +220,7 @@ def invoke_command(args: ty.List[str]) -> int:
         CommandTooLong: `args` exceeds built in command line length limit on Windows.
     """
     try:
-        return subprocess.call(args)
+        return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError as err:
         if os.name != "nt":
             raise

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -220,7 +220,7 @@ def invoke_command(args: ty.List[str]) -> int:
         CommandTooLong: `args` exceeds built in command line length limit on Windows.
     """
     try:
-        # return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         print(result)
         if result.returncode != 0:

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -221,18 +221,9 @@ def invoke_command(args: ty.List[str]) -> int:
     """
     try:
         try:
-            result = subprocess.run(args,
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True  # decode bytes -> str
-            )
-            return result
+            return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except subprocess.CalledProcessError as e:
-            print("❌ FFmpeg failed!")
-            print("Return code:", e.returncode)
-            print("Error output:\n", e.stderr)   # full ffmpeg log
-        # return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            print(f"FFmpeg failed - {e}")
     except OSError as err:
         if os.name != "nt":
             raise

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -220,7 +220,8 @@ def invoke_command(args: ty.List[str]) -> int:
         CommandTooLong: `args` exceeds built in command line length limit on Windows.
     """
     try:
-        return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return subprocess.call(args)
+        # return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError as err:
         if os.name != "nt":
             raise

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -221,14 +221,8 @@ def invoke_command(args: ty.List[str]) -> int:
     """
     try:
         return subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        print(result)
-        if result.returncode != 0:
-            print("ffmpeg failed!")
-            print("Error log:\n", result.stderr)
-        return result.returncode
     except subprocess.CalledProcessError as e:
-        print(f"FFmpeg failed - {e}")
+        raise RuntimeError(f"Error in subprocess execution: {e}")
     except OSError as err:
         if os.name != "nt":
             raise

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -970,8 +970,8 @@ class SceneManager:
         self._frame_size: ty.Tuple[int, int] = None
         self._frame_size_errors: int = 0
         self._base_timecode: ty.Optional[FrameTimecode] = None
-        self._downscale: int = 3
-        self._auto_downscale: bool = False
+        self._downscale: int = 1
+        self._auto_downscale: bool = True
         # Interpolation method to use when downscaling. Defaults to linear interpolation
         # as a good balance between quality and performance.
         self._interpolation: Interpolation = Interpolation.LINEAR
@@ -1234,7 +1234,6 @@ class SceneManager:
             raise ValueError("end_time must be greater than or equal to 0!")
 
         effective_frame_size = video.frame_size
-    
         if self._crop:
             logger.debug(f"Crop set: top left = {self.crop[0:2]}, bottom right = {self.crop[2:4]}")
             x0, y0, x1, y1 = self._crop
@@ -1256,7 +1255,7 @@ class SceneManager:
             w, __ = effective_frame_size
             downscale_factor = round(w / 1280)
             downscale_factor = 1 if downscale_factor < 1 else downscale_factor
-            downscale_factor = self._downscale
+        
         logger.info(
             "Processing resolution: %d x %d, downscale: %1.1f",
             int(effective_frame_size[0] / downscale_factor),

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -970,8 +970,8 @@ class SceneManager:
         self._frame_size: ty.Tuple[int, int] = None
         self._frame_size_errors: int = 0
         self._base_timecode: ty.Optional[FrameTimecode] = None
-        self._downscale: int = 1
-        self._auto_downscale: bool = True
+        self._downscale: int = 3
+        self._auto_downscale: bool = False
         # Interpolation method to use when downscaling. Defaults to linear interpolation
         # as a good balance between quality and performance.
         self._interpolation: Interpolation = Interpolation.LINEAR
@@ -1234,6 +1234,7 @@ class SceneManager:
             raise ValueError("end_time must be greater than or equal to 0!")
 
         effective_frame_size = video.frame_size
+    
         if self._crop:
             logger.debug(f"Crop set: top left = {self.crop[0:2]}, bottom right = {self.crop[2:4]}")
             x0, y0, x1, y1 = self._crop
@@ -1252,8 +1253,11 @@ class SceneManager:
         if self.auto_downscale:
             downscale_factor = compute_downscale_factor(max(effective_frame_size))
         else:
-            downscale_factor = self.downscale
-        logger.debug(
+            w, __ = effective_frame_size
+            downscale_factor = round(w / 1280)
+            downscale_factor = 1 if downscale_factor < 1 else downscale_factor
+            downscale_factor = self._downscale
+        logger.info(
             "Processing resolution: %d x %d, downscale: %1.1f",
             int(effective_frame_size[0] / downscale_factor),
             int(effective_frame_size[1] / downscale_factor),

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -1186,6 +1186,7 @@ class SceneManager:
         show_progress: bool = False,
         callback: ty.Optional[ty.Callable[[np.ndarray, int], None]] = None,
         frame_source: ty.Optional[VideoStream] = None,
+        detection_fps: int = 5
     ) -> int:
         """Perform scene detection on the given video using the added SceneDetectors, returning the
         number of frames processed. Results can be obtained by calling :meth:`get_scene_list` or
@@ -1295,7 +1296,7 @@ class SceneManager:
         self._stop.clear()
         decode_thread = threading.Thread(
             target=SceneManager._decode_thread,
-            args=(self, video, frame_skip, downscale_factor, end_time, frame_queue),
+            args=(self, video, frame_skip, downscale_factor, end_time, frame_queue, detection_fps),
             daemon=True,
         )
         decode_thread.start()
@@ -1342,6 +1343,7 @@ class SceneManager:
         downscale_factor: float,
         end_time: FrameTimecode,
         out_queue: queue.Queue,
+        detection_fps: int
     ):
         try:
             while not self._stop.is_set():
@@ -1349,7 +1351,7 @@ class SceneManager:
                 # We don't do any kind of locking here since the worst-case of this being wrong
                 # is that we do some extra work, and this function should never mutate any data
                 # (all of which should be modified under the GIL).
-                frame_im = video.read()
+                frame_im = video.read_fps(target_fps=detection_fps)
                 if frame_im is False:
                     break
                 # Verify the decoded frame size against the video container's reported
@@ -1397,7 +1399,7 @@ class SceneManager:
 
                 if frame_skip > 0:
                     for _ in range(frame_skip):
-                        if not video.read(decode=False):
+                        if not video.read_fps(decode=False, target_fps=detection_fps):
                             break
                 # End time includes the presentation time of the frame, but the `position`
                 # property of a VideoStream references the beginning of the frame in time.

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -66,8 +66,8 @@ for details.  Sorry about that!
 FFMPEG_PATH: ty.Optional[str] = get_ffmpeg_path()
 """Relative path to the ffmpeg binary on this system, if any (will be None if not available)."""
 
-# DEFAULT_FFMPEG_ARGS = "-c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
 DEFAULT_FFMPEG_ARGS = "-map 0:v:0 -map 0:a:0 -c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
+DEFAULT_FFMPEG_ARGS_COMPLEX = "-c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
 """Default arguments passed to ffmpeg when invoking the `split_video_ffmpeg` function."""
 
 ##
@@ -257,6 +257,7 @@ def split_video_mkvmerge(
         logger.error("Error splitting video (mkvmerge returned %d).", ret_val)
     return ret_val
 
+
 def split_video_ffmpeg(
     input_video_path: str,
     scene_list: ty.Iterable[TimecodePair],
@@ -372,7 +373,6 @@ def split_video_ffmpeg(
                 str(output_fps),
             ]
             call_list += arg_override
-            call_list += ["-sn"]
             call_list += [str(output_path)]
             ret_val = invoke_command(call_list)
             if show_output and i == 0 and len(scene_list) > 1:
@@ -403,7 +403,8 @@ def split_video_ffmpeg(
         )
     return ret_val
 
-def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps):
+
+def build_ffmpeg_complex_splits_command(input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps):
     """
     input_video_path : str
     scene_list       : list of (start_time, end_time) in seconds
@@ -468,18 +469,14 @@ def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata
     return cmd
 
 
-def split_video_ffmpeg_filter(
+def split_video_ffmpeg_filter_complex(
     input_video_path: str,
     scene_list: ty.Iterable[TimecodePair],
     output_dir: ty.Optional[Path] = None,
     output_file_template: str = "$VIDEO_NAME-Scene-$SCENE_NUMBER.mp4",
     video_name: ty.Optional[str] = None,
     output_fps: int = 25,
-    arg_override: str = DEFAULT_FFMPEG_ARGS,
-    show_progress: bool = False,
-    show_output: bool = False,
-    suppress_output=None,
-    hide_progress=None,
+    arg_override: str = DEFAULT_FFMPEG_ARGS_COMPLEX,
     formatter: ty.Optional[PathFormatter] = None,
 ) -> int:
     """Calls the ffmpeg command on the input video, generating a new video for
@@ -496,10 +493,6 @@ def split_video_ffmpeg_filter(
         video_name (str): Name of the video to be substituted in output_file_template. If not
             passed will be calculated from input_video_path automatically.
         arg_override (str): Allows overriding the arguments passed to ffmpeg for encoding.
-        show_progress (bool): If True, will show progress bar provided by tqdm (if installed).
-        show_output (bool): If True, will show output from ffmpeg for first split.
-        suppress_output: [DEPRECATED] DO NOT USE. For backwards compatibility only.
-        hide_progress: [DEPRECATED] DO NOT USE. For backwards compatibility only.
         formatter: Custom formatter callback. Overrides `output_file_template`.
 
     Returns:
@@ -539,21 +532,17 @@ def split_video_ffmpeg_filter(
     )
 
     try:
-        step_size = 5
-        for idx in range(len(scene_list), step_size):
-            # total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
-            cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
-            cmd += ["-nostdin", "-y", "-v", "error"]
-            cmd += build_ffmpeg_command(
-                input_video_path, scene_list[idx:idx+step_size], formatter, video_metadata, 
-                arg_override, output_dir, output_fps
-            )
-            ret_val = invoke_command(cmd)
-            # print(" ".join(cmd))
-            if ret_val != 0:
-                logger.error(f"Error splitting video (ffmpeg returned {ret_val}).")
-
-            gc.collect()
+        # total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
+        cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
+        cmd += ["-nostdin", "-y", "-v", "error"]
+        cmd += build_ffmpeg_complex_splits_command(
+            input_video_path, scene_list, formatter, video_metadata, 
+            arg_override, output_dir, output_fps
+        )
+        ret_val = invoke_command(cmd)
+        if ret_val != 0:
+            logger.error(f"Error splitting video (ffmpeg returned {ret_val}).")
+        gc.collect()
 
     except CommandTooLong:
         logger.error(COMMAND_TOO_LONG_STRING)
@@ -563,4 +552,3 @@ def split_video_ffmpeg_filter(
             " Please install ffmpeg to enable video output support."
         )
     return ret_val
-

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -363,7 +363,7 @@ def split_video_ffmpeg(
             ]
             call_list += arg_override
             call_list += ["-sn"]
-            call_list += ["-threads", "1"]
+            call_list += ["-threads", "2"]
             call_list += [str(output_path)]
             ret_val = invoke_command(call_list)
             if show_output and i == 0 and len(scene_list) > 1:

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -393,18 +393,21 @@ def split_video_ffmpeg(
     )
 
     try:
-        # total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
-        cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
-        cmd += ["-nostdin", "-y", "-v", "error"]
-        cmd += build_ffmpeg_command(
-            input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps
-        )
-        ret_val = invoke_command(cmd)
-        # print(" ".join(cmd))
-        if ret_val != 0:
-            logger.error(f"Error splitting video (ffmpeg returned {ret_val}).")
+        step_size = 5
+        for idx in range(len(scene_list), step_size):
+            # total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
+            cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
+            cmd += ["-nostdin", "-y", "-v", "error"]
+            cmd += build_ffmpeg_command(
+                input_video_path, scene_list[idx:idx+step_size], formatter, video_metadata, 
+                arg_override, output_dir, output_fps
+            )
+            ret_val = invoke_command(cmd)
+            # print(" ".join(cmd))
+            if ret_val != 0:
+                logger.error(f"Error splitting video (ffmpeg returned {ret_val}).")
 
-        gc.collect()
+            gc.collect()
 
     except CommandTooLong:
         logger.error(COMMAND_TOO_LONG_STRING)

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -257,7 +257,7 @@ def split_video_mkvmerge(
     return ret_val
 
 
-def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata, arg_override):
+def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps):
     """
     input_video_path : str
     scene_list       : list of (start_time, end_time) in seconds
@@ -285,8 +285,18 @@ def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata
         )
         durations.append(end - start)
         scene_metadata = SceneMetadata(index=i, start=start, end=end)
+
+        output_path = Path(formatter(scene=scene_metadata, video=video_metadata))
+        if output_dir:
+            output_path = Path(output_dir) / output_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path = re.sub(
+            r"(P\d+)-S(\d+)-F(\d+)-F(\d+)-FPS(\d+)",
+            r"\1_S\2_F\3_F\4_FPS\5",
+            str(output_path),
+        )
         output_paths.append(
-            str(Path(formatter(scene=scene_metadata, video=video_metadata)))
+            str(output_path)
         )
 
     # join filter graph
@@ -304,6 +314,7 @@ def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata
         f"{(filter_complex_str[:-1])}",
     ]
     cmd += arg_override
+    cmd += ["-r",  str(output_fps)] 
     # add mapping for each output
     for i, out in enumerate(output_paths):
         cmd += ["-map", f"[v{i}t]", "-map", f"[a{i}t]", out]
@@ -382,14 +393,12 @@ def split_video_ffmpeg(
     )
 
     try:
-        total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
-
+        # total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
         cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
         cmd += ["-nostdin", "-y", "-v", "error"]
         cmd += build_ffmpeg_command(
-            input_video_path, scene_list, formatter, video_metadata, arg_override
+            input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps
         )
-        cmd += ["-threads", "2"]
         ret_val = invoke_command(cmd)
         # print(" ".join(cmd))
         if ret_val != 0:

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -40,6 +40,7 @@ import typing as ty
 from dataclasses import dataclass
 from pathlib import Path
 import re
+import gc
 
 
 from scenedetect.common import FrameTimecode, TimecodePair
@@ -362,6 +363,7 @@ def split_video_ffmpeg(
             ]
             call_list += arg_override
             call_list += ["-sn"]
+            call_list += ["-threads", "1"]
             call_list += [str(output_path)]
             ret_val = invoke_command(call_list)
             if show_output and i == 0 and len(scene_list) > 1:
@@ -374,6 +376,8 @@ def split_video_ffmpeg(
                 break
             if progress_bar:
                 progress_bar.update(duration.get_frames())
+            
+            gc.collect()
 
         if progress_bar:
             progress_bar.close()

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -386,6 +386,8 @@ def split_video_ffmpeg(
             if progress_bar:
                 progress_bar.update(duration.get_frames())
 
+            gc.collect()
+
         if progress_bar:
             progress_bar.close()
         if show_output:

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -44,7 +44,13 @@ import gc
 
 
 from scenedetect.common import FrameTimecode, TimecodePair
-from scenedetect.platform import CommandTooLong, Template, get_ffmpeg_path, invoke_command, tqdm
+from scenedetect.platform import (
+    CommandTooLong,
+    Template,
+    get_ffmpeg_path,
+    invoke_command,
+    tqdm,
+)
 
 logger = logging.getLogger("pyscenedetect")
 
@@ -60,7 +66,7 @@ for details.  Sorry about that!
 FFMPEG_PATH: ty.Optional[str] = get_ffmpeg_path()
 """Relative path to the ffmpeg binary on this system, if any (will be None if not available)."""
 
-DEFAULT_FFMPEG_ARGS = "-map 0:v:0 -map 0:a:0 -c:v libx264 -preset veryfast -crf 22 -c:a aac -sn"
+DEFAULT_FFMPEG_ARGS = "-c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
 """Default arguments passed to ffmpeg when invoking the `split_video_ffmpeg` function."""
 
 ##
@@ -132,7 +138,11 @@ def default_formatter(template: str) -> PathFormatter:
     """
     MIN_DIGITS = 3
     format_scene_number: PathFormatter = lambda video, scene: (
-        ("%0" + str(max(MIN_DIGITS, math.floor(math.log(video.total_scenes, 10)) + 1)) + "d")
+        (
+            "%0"
+            + str(max(MIN_DIGITS, math.floor(math.log(video.total_scenes, 10)) + 1))
+            + "d"
+        )
         % (scene.index + 1)
     )
     formatter: PathFormatter = lambda video, scene: Template(template).safe_substitute(
@@ -247,6 +257,60 @@ def split_video_mkvmerge(
     return ret_val
 
 
+def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata):
+    """
+    input_video_path : str
+    scene_list       : list of (start_time, end_time) in seconds
+    output_paths     : list of str output filenames
+    """
+    n = len(scene_list)
+    durations = []
+    output_paths = []
+
+    # split/asplit heads
+    filter_complex = [
+        f"[0:v]split={n}" + "".join(f"[v{i}]" for i in range(n)) + ";",
+        f"[0:a]asplit={n}" + "".join(f"[a{i}]" for i in range(n)) + ";",
+    ]
+
+    # build each trim/atrim
+    for i, (start, end) in enumerate(scene_list):
+        ss = start.get_seconds()
+        es = end.get_seconds()
+        filter_complex.append(
+            f"[v{i}]trim=start={ss}:end={es},setpts=PTS-STARTPTS[v{i}t];"
+        )
+        filter_complex.append(
+            f"[a{i}]atrim=start={ss}:end={es},asetpts=PTS-STARTPTS[a{i}t];"
+        )
+        durations.append(end - start)
+        scene_metadata = SceneMetadata(index=i, start=start, end=end)
+        output_paths.append(
+            str(Path(formatter(scene=scene_metadata, video=video_metadata)))
+        )
+
+    # join filter graph
+    filter_complex_str = " ".join(filter_complex)
+
+    # base ffmpeg command
+    cmd = [
+        "-i",
+        input_video_path,
+        "-filter_complex_threads",
+        "2",
+        "-filter_threads",
+        "2",
+        "-filter_complex",
+        f"{filter_complex_str[:-1]}",
+    ]
+
+    # add mapping for each output
+    for i, out in enumerate(output_paths):
+        cmd += ["-map", f"[v{i}t]", "-map", f"[a{i}t]", out]
+
+    return cmd
+
+
 def split_video_ffmpeg(
     input_video_path: str,
     scene_list: ty.Iterable[TimecodePair],
@@ -291,17 +355,13 @@ def split_video_ffmpeg(
         if len(input_video_path) > 1:
             raise ValueError("Concatenating multiple input videos is not supported.")
         input_video_path = input_video_path[0]
-    if suppress_output is not None:
-        logger.error("suppress_output is deprecated, use show_output instead.")
-        show_output = not suppress_output
-    if hide_progress is not None:
-        logger.error("hide_progress is deprecated, use show_progress instead.")
-        show_progress = not hide_progress
 
     if not scene_list:
         return 0
 
-    logger.info("Splitting video with ffmpeg, output path template:\n  %s", output_file_template)
+    logger.info(
+        "Splitting video with ffmpeg, output path template:\n  %s", output_file_template
+    )
     if output_dir:
         logger.info("Output folder:\n  %s", output_file_template)
 
@@ -325,67 +385,22 @@ def split_video_ffmpeg(
         progress_bar = None
         total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
         if show_progress:
-            progress_bar = tqdm(total=total_frames, unit="frame", miniters=1, dynamic_ncols=True)
-        processing_start_time = time.time()
-        for i, (start_time, end_time) in enumerate(scene_list):
-            duration = end_time - start_time
-            scene_metadata = SceneMetadata(index=i, start=start_time, end=end_time)
-            output_path = Path(formatter(scene=scene_metadata, video=video_metadata))
-            if output_dir:
-                output_path = Path(output_dir) / output_path
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path = re.sub(
-                r"(P\d+)-S(\d+)-F(\d+)-F(\d+)-FPS(\d+)",
-                r"\1_S\2_F\3_F\4_FPS\5",
-                str(output_path),
+            progress_bar = tqdm(
+                total=total_frames, unit="frame", miniters=1, dynamic_ncols=True
             )
 
-            # Gracefully handle case where FFMPEG_PATH might be unset.
-            call_list = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
-            if not show_output:
-                call_list += ["-v", "quiet"]
-            elif i > 0:
-                # Only show ffmpeg output for the first call, which will display any
-                # errors if it fails, and then break the loop. We only show error messages
-                # for the remaining calls.
-                call_list += ["-v", "error"]
-            call_list += [
-                "-nostdin",
-                "-y",
-                "-ss",
-                str(start_time.get_seconds()),
-                "-i",
-                input_video_path,
-                "-t",
-                str(duration.get_seconds()),
-                "-r",
-                str(output_fps),
-            ]
-            call_list += arg_override
-            call_list += ["-sn"]
-            call_list += ["-threads", "2"]
-            call_list += [str(output_path)]
-            ret_val = invoke_command(call_list)
-            if show_output and i == 0 and len(scene_list) > 1:
-                logger.info(
-                    "Output from ffmpeg for Scene 1 shown above, splitting remaining scenes..."
-                )
-            if ret_val != 0:
-                # TODO: Capture stdout/stderr and display it on any failed calls.
-                logger.error("Error splitting video (ffmpeg returned %d).", ret_val)
-                break
-            if progress_bar:
-                progress_bar.update(duration.get_frames())
-            
-            gc.collect()
+        cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
+        cmd += ["-nostdin", "-y", "-v", "error"]
+        cmd += build_ffmpeg_command(
+            input_video_path, scene_list, formatter, video_metadata
+        )
+        cmd += arg_override
+        cmd += ["-threads", "2"]
+        ret_val = invoke_command(cmd)
+        if ret_val != 0:
+            logger.error("Error splitting video (ffmpeg returned %d).", ret_val)
 
-        if progress_bar:
-            progress_bar.close()
-        if show_output:
-            logger.info(
-                "Average processing speed %.2f frames/sec.",
-                float(total_frames) / (time.time() - processing_start_time),
-            )
+        gc.collect()
 
     except CommandTooLong:
         logger.error(COMMAND_TOO_LONG_STRING)

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -66,7 +66,8 @@ for details.  Sorry about that!
 FFMPEG_PATH: ty.Optional[str] = get_ffmpeg_path()
 """Relative path to the ffmpeg binary on this system, if any (will be None if not available)."""
 
-DEFAULT_FFMPEG_ARGS = "-c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
+# DEFAULT_FFMPEG_ARGS = "-c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
+DEFAULT_FFMPEG_ARGS = "-map 0:v:0 -map 0:a:0 -c:v libx264 -preset veryfast -crf 22 -c:a aac -sn -threads 2"
 """Default arguments passed to ffmpeg when invoking the `split_video_ffmpeg` function."""
 
 ##
@@ -256,6 +257,151 @@ def split_video_mkvmerge(
         logger.error("Error splitting video (mkvmerge returned %d).", ret_val)
     return ret_val
 
+def split_video_ffmpeg(
+    input_video_path: str,
+    scene_list: ty.Iterable[TimecodePair],
+    output_dir: ty.Optional[Path] = None,
+    output_file_template: str = "$VIDEO_NAME-Scene-$SCENE_NUMBER.mp4",
+    video_name: ty.Optional[str] = None,
+    output_fps: int = 25,
+    arg_override: str = DEFAULT_FFMPEG_ARGS,
+    show_progress: bool = False,
+    show_output: bool = False,
+    suppress_output=None,
+    hide_progress=None,
+    formatter: ty.Optional[PathFormatter] = None,
+) -> int:
+    """Calls the ffmpeg command on the input video, generating a new video for
+    each scene based on the start/end timecodes.
+
+    Arguments:
+        input_video_path: Path to the video to be split.
+        scene_list (List[ty.Tuple[FrameTimecode, FrameTimecode]]): List of scenes
+            (pairs of FrameTimecodes) denoting the start/end frames of each scene.
+        output_dir: Directory to output videos. If not set, output will be in working directory.
+        output_file_template (str): Template to use for generating output filenames.
+            The following variables will be replaced in the template for each scene:
+            $VIDEO_NAME, $SCENE_NUMBER, $START_TIME, $END_TIME, $START_FRAME, $END_FRAME
+        video_name (str): Name of the video to be substituted in output_file_template. If not
+            passed will be calculated from input_video_path automatically.
+        arg_override (str): Allows overriding the arguments passed to ffmpeg for encoding.
+        show_progress (bool): If True, will show progress bar provided by tqdm (if installed).
+        show_output (bool): If True, will show output from ffmpeg for first split.
+        suppress_output: [DEPRECATED] DO NOT USE. For backwards compatibility only.
+        hide_progress: [DEPRECATED] DO NOT USE. For backwards compatibility only.
+        formatter: Custom formatter callback. Overrides `output_file_template`.
+
+    Returns:
+        Return code of invoking ffmpeg (0 on success). If scene_list is empty, will
+        still return 0, but no commands will be invoked.
+    """
+    # Handle backwards compatibility with v0.5 API.
+    if isinstance(input_video_path, list):
+        logger.error("Using a list of paths is deprecated. Pass a single path instead.")
+        if len(input_video_path) > 1:
+            raise ValueError("Concatenating multiple input videos is not supported.")
+        input_video_path = input_video_path[0]
+    if suppress_output is not None:
+        logger.error("suppress_output is deprecated, use show_output instead.")
+        show_output = not suppress_output
+    if hide_progress is not None:
+        logger.error("hide_progress is deprecated, use show_progress instead.")
+        show_progress = not hide_progress
+
+    if not scene_list:
+        return 0
+
+    logger.info("Splitting video with ffmpeg, output path template:\n  %s", output_file_template)
+    if output_dir:
+        logger.info("Output folder:\n  %s", output_file_template)
+
+    if video_name is None:
+        video_name = Path(input_video_path).stem
+
+    arg_override = arg_override.replace('\\"', '"')
+
+    ret_val = 0
+    arg_override = arg_override.split(" ")
+    scene_num_format = "%0"
+    scene_num_format += str(max(3, math.floor(math.log(len(scene_list), 10)) + 1)) + "d"
+
+    if formatter is None:
+        formatter = default_formatter(output_file_template)
+    video_metadata = VideoMetadata(
+        name=video_name, path=input_video_path, total_scenes=len(scene_list)
+    )
+
+    try:
+        progress_bar = None
+        total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
+        if show_progress:
+            progress_bar = tqdm(total=total_frames, unit="frame", miniters=1, dynamic_ncols=True)
+        processing_start_time = time.time()
+        for i, (start_time, end_time) in enumerate(scene_list):
+            duration = end_time - start_time
+            scene_metadata = SceneMetadata(index=i, start=start_time, end=end_time)
+            output_path = Path(formatter(scene=scene_metadata, video=video_metadata))
+            if output_dir:
+                output_path = Path(output_dir) / output_path
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path = re.sub(
+                r"(P\d+)-S(\d+)-F(\d+)-F(\d+)-FPS(\d+)",
+                r"\1_S\2_F\3_F\4_FPS\5",
+                str(output_path),
+            )
+
+            # Gracefully handle case where FFMPEG_PATH might be unset.
+            call_list = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
+            if not show_output:
+                call_list += ["-v", "quiet"]
+            elif i > 0:
+                # Only show ffmpeg output for the first call, which will display any
+                # errors if it fails, and then break the loop. We only show error messages
+                # for the remaining calls.
+                call_list += ["-v", "error"]
+            call_list += [
+                "-nostdin",
+                "-y",
+                "-ss",
+                str(start_time.get_seconds()),
+                "-i",
+                input_video_path,
+                "-t",
+                str(duration.get_seconds()),
+                "-r",
+                str(output_fps),
+            ]
+            call_list += arg_override
+            call_list += ["-sn"]
+            call_list += [str(output_path)]
+            ret_val = invoke_command(call_list)
+            if show_output and i == 0 and len(scene_list) > 1:
+                logger.info(
+                    "Output from ffmpeg for Scene 1 shown above, splitting remaining scenes..."
+                )
+            if ret_val != 0:
+                # TODO: Capture stdout/stderr and display it on any failed calls.
+                logger.error("Error splitting video (ffmpeg returned %d).", ret_val)
+                break
+            if progress_bar:
+                progress_bar.update(duration.get_frames())
+
+        if progress_bar:
+            progress_bar.close()
+        if show_output:
+            logger.info(
+                "Average processing speed %.2f frames/sec.",
+                float(total_frames) / (time.time() - processing_start_time),
+            )
+
+    except CommandTooLong:
+        logger.error(COMMAND_TOO_LONG_STRING)
+    except OSError:
+        logger.error(
+            "ffmpeg could not be found on the system."
+            " Please install ffmpeg to enable video output support."
+        )
+    return ret_val
 
 def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata, arg_override, output_dir, output_fps):
     """
@@ -322,7 +468,7 @@ def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata
     return cmd
 
 
-def split_video_ffmpeg(
+def split_video_ffmpeg_filter(
     input_video_path: str,
     scene_list: ty.Iterable[TimecodePair],
     output_dir: ty.Optional[Path] = None,
@@ -417,3 +563,4 @@ def split_video_ffmpeg(
             " Please install ffmpeg to enable video output support."
         )
     return ret_val
+

--- a/scenedetect/video_splitter.py
+++ b/scenedetect/video_splitter.py
@@ -257,7 +257,7 @@ def split_video_mkvmerge(
     return ret_val
 
 
-def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata):
+def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata, arg_override):
     """
     input_video_path : str
     scene_list       : list of (start_time, end_time) in seconds
@@ -301,9 +301,9 @@ def build_ffmpeg_command(input_video_path, scene_list, formatter, video_metadata
         "-filter_threads",
         "2",
         "-filter_complex",
-        f"{filter_complex_str[:-1]}",
+        f"{(filter_complex_str[:-1])}",
     ]
-
+    cmd += arg_override
     # add mapping for each output
     for i, out in enumerate(output_paths):
         cmd += ["-map", f"[v{i}t]", "-map", f"[a{i}t]", out]
@@ -382,23 +382,18 @@ def split_video_ffmpeg(
     )
 
     try:
-        progress_bar = None
         total_frames = scene_list[-1][1].get_frames() - scene_list[0][0].get_frames()
-        if show_progress:
-            progress_bar = tqdm(
-                total=total_frames, unit="frame", miniters=1, dynamic_ncols=True
-            )
 
         cmd = [FFMPEG_PATH if FFMPEG_PATH is not None else "ffmpeg"]
         cmd += ["-nostdin", "-y", "-v", "error"]
         cmd += build_ffmpeg_command(
-            input_video_path, scene_list, formatter, video_metadata
+            input_video_path, scene_list, formatter, video_metadata, arg_override
         )
-        cmd += arg_override
         cmd += ["-threads", "2"]
         ret_val = invoke_command(cmd)
+        # print(" ".join(cmd))
         if ret_val != 0:
-            logger.error("Error splitting video (ffmpeg returned %d).", ret_val)
+            logger.error(f"Error splitting video (ffmpeg returned {ret_val}).")
 
         gc.collect()
 


### PR DESCRIPTION
Improve Scene Detection in detecting smoother transitions
- Merging the ffmpeg loop which decoded video for each chunk into a single command using filter_complex to get all chunks in one run. This is costly in terms of RAM so not using this
- Improving scene detection by adding a reduced frame rate sampling which can help in detecting transitions between scenes which are missed otherwise
- Also adjusting the thresholds
- Though current solution still fails on very smooth transitions